### PR TITLE
Updates to media size/position, changes to video preferences

### DIFF
--- a/theme.xml
+++ b/theme.xml
@@ -149,12 +149,6 @@ Special thanks to Cosmo0 too who contribute with some art, various logos and imp
 	<pos>0.79 0.82</pos>
 	<size>0.25 0.2</size>
  </text>
-
- <image name="md_image">
-	<origin>0.5 0.5</origin>
-	<pos>0.7 0.4</pos>
-	<maxSize>0.51 0.51</maxSize>
- </image>
  
 <textlist name="gamelist">
 	<selectorColor>ffffff</selectorColor>
@@ -192,7 +186,14 @@ Special thanks to Cosmo0 too who contribute with some art, various logos and imp
 	<pos>1 1</pos>
 </rating>
 
+</view>
 
+<view name="basic, detailed, grid">
+ <image name="md_image">
+	<origin>0.5 0.5</origin>
+	<pos>0.6925 0.3915</pos>
+	<maxSize>0.4292 0.5297</maxSize>
+ </image>
 </view>
 
 <feature supported="video">
@@ -200,11 +201,11 @@ Special thanks to Cosmo0 too who contribute with some art, various logos and imp
 <view name="video">
  <video name="md_video">
 	<origin>0.5 0.5</origin>
-	<pos>0.7 0.4</pos>
-	<maxSize>0.51 0.51</maxSize>
-	<delay>0.1</delay>
+	<pos>0.6925 0.3915</pos>
+	<maxSize>0.4292 0.5297</maxSize>
+	<delay>2</delay>
 	<showSnapshotNoVideo>true</showSnapshotNoVideo>
-	<showSnapshotDelay>false</showSnapshotDelay>
+	<showSnapshotDelay>true</showSnapshotDelay>
  </video>
  
  <image name="md_marquee">


### PR DESCRIPTION
- Move md_image out of video view, so that gamelist images no longer remain under a video while playing

- Under video features, change delay to 2, and enable showSnapshotDelay. This should mean if you have scraped both an image and video for the same game, the image will display first for 2 seconds before fading and playing the video

- Slight horizontal and vertical re-position of image/video in gamelist view so it is almost exactly central within the surrounding space

- Change maximum size (horizontal and vertical) of md_image and video to stop widescreen images and videos appearing oversized, causing overshoot (eg. PSP). However the max size set on 1920x1080 still allows for images up to 824x572 which is the size based on the design. More conventional image sizes (800x600) still appear central but will have slight variable padding either side depending on size. Images below the maximum size threshold will be scaled up until one of the maximum size values is met.